### PR TITLE
Remove unnecessary reserialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
 use anyhow::{Context, Result};
-use serde::de::DeserializeOwned;
-use serde::Serialize;
 use serde_json::Value;
 
 use cairo_lang_starknet::casm_contract_class::CasmContractClass;
@@ -11,7 +9,7 @@ use cairo_lang_starknet_sierra_1_0_0::casm_contract_class::CasmContractClass as 
 use cairo_lang_starknet_sierra_1_0_0::contract_class::ContractClass as ContractClassSierraV1;
 
 /// `sierra_json` should be a json containing `sierra_program` and `entry_points_by_type`
-pub fn compile(mut sierra_json: Value) -> Result<CasmContractClass> {
+pub fn compile(mut sierra_json: Value) -> Result<Value> {
     sierra_json["abi"] = Value::Null;
     sierra_json["sierra_program_debug_info"] = Value::Null;
     sierra_json["contract_class_version"] = Value::String(String::new());
@@ -20,7 +18,7 @@ pub fn compile(mut sierra_json: Value) -> Result<CasmContractClass> {
         ($sierra_type:ty, $casm_type:ty) => {{
             let sierra_class = serde_json::from_value::<$sierra_type>(sierra_json.clone()).unwrap();
             let casm_class = <$casm_type>::from_contract_class(sierra_class, true).unwrap();
-            return Ok(old_casm_to_newest_casm::<$casm_type>(&casm_class));
+            return Ok(serde_json::to_value(&casm_class)?);
         }};
     }
 
@@ -36,16 +34,6 @@ pub fn compile(mut sierra_json: Value) -> Result<CasmContractClass> {
             )
         }
     }
-}
-
-/// Converts `CasmContractClass` from the old `cairo_lang_starknet` library version
-/// to the `CasmContractClass` from the newest version
-fn old_casm_to_newest_casm<T>(value: &T) -> CasmContractClass
-where
-    T: Serialize + DeserializeOwned,
-{
-    let serialized = serde_json::to_value(value).unwrap();
-    serde_json::from_value::<CasmContractClass>(serialized).unwrap()
 }
 
 /// Extracts sierra version from the program

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,8 +31,7 @@ fn main_execution() -> Result<bool> {
     let sierra_json =
         serde_json::from_reader(sierra_file).context("Unable to read sierra json file")?;
 
-    let casm = compile(sierra_json)?;
-    let casm_json = serde_json::to_value(casm)?;
+    let casm_json = compile(sierra_json)?;
 
     match args.casm_output_path {
         Some(output_path) => {


### PR DESCRIPTION
Closes #16 

It seems that we shouldn't serialize and deserialize `CasmContractClass` just to check if it fits into the newest Casm format 