### PR TITLE
Update before publishing to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,3 @@ fs_extra = "1.3.0"
 test-case = "3.3.1"
 num-bigint = "0.4.4"
 cairo-lang-casm = { version = "2.6.0", features = ["serde"] }
-
-[[bin]]
-name = "universal-sierra-compiler"
-path = "src/main.rs"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ curl -L https://raw.githubusercontent.com/software-mansion/universal-sierra-comp
 
 ## Usage
 
+### Command line tool
 Tool consist of two subcommands:
 
 - `compile-contract`
@@ -91,3 +92,13 @@ $ universal-sierra-compiler \
       --sierra-path ./path/to/sierra.json
       --output-path ./path/to/casm.json
 ```
+
+### Library
+
+Library crate exports two functions: 
+
+- `compile_contract(serde_json::Value) -> Result<serde_json::Value>`
+- `compile_raw(serde_json::Value) -> Result<serde_json::Value>`
+
+They do the same as their CLI counterparts. However, they accept the whole program in json format as a parameter, precisely a `json_serde::Value`.
+Return value is the compiled program inside `Result<serde_json::Value>`.

--- a/src/commands/compile_contract.rs
+++ b/src/commands/compile_contract.rs
@@ -22,6 +22,7 @@ pub struct CompileContract {
     pub output_path: Option<PathBuf>,
 }
 
+/// Compiles Sierra of the Starknet contract.
 pub fn compile(mut sierra_json: Value) -> Result<Value> {
     sierra_json["abi"] = Value::Null;
     sierra_json["sierra_program_debug_info"] = Value::Null;

--- a/src/commands/compile_raw.rs
+++ b/src/commands/compile_raw.rs
@@ -19,6 +19,7 @@ pub struct CompileRaw {
     pub output_path: Option<PathBuf>,
 }
 
+/// Compiles Sierra of the plain Cairo code.
 pub fn compile(sierra_program: Value) -> Result<Value> {
     let sierra_program: Program = serde_json::from_value(sierra_program)
         .context("Unable to deserialize Sierra program. Make sure it is in a correct format")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,4 @@
-pub mod commands;
+mod commands;
+
+pub use commands::compile_contract::compile as compile_contract;
+pub use commands::compile_raw::compile as compile_raw;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,11 @@ use console::style;
 use serde_json::{to_writer, Value};
 use std::fs::File;
 use std::path::PathBuf;
-use universal_sierra_compiler::commands;
-use universal_sierra_compiler::commands::compile_contract::CompileContract;
-use universal_sierra_compiler::commands::compile_raw::CompileRaw;
+
+mod commands;
+
+use commands::compile_contract::CompileContract;
+use commands::compile_raw::CompileRaw;
 
 #[derive(Parser)]
 #[command(version)]

--- a/tests/integration/compile_contract.rs
+++ b/tests/integration/compile_contract.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 use test_case::test_case;
-use universal_sierra_compiler::commands;
+use universal_sierra_compiler::compile_contract;
 
 #[test]
 fn wrong_json() {
@@ -8,7 +8,7 @@ fn wrong_json() {
         "wrong": "data"
     });
 
-    let casm_class = commands::compile_contract::compile(sierra_json);
+    let casm_class = compile_contract(sierra_json);
     assert!(casm_class.is_err());
 }
 
@@ -25,6 +25,6 @@ fn compile_sierra(sierra_version: &str) {
             .unwrap();
     let sierra_json = serde_json::from_reader(file).unwrap();
 
-    let casm_class = commands::compile_contract::compile(sierra_json);
+    let casm_class = compile_contract(sierra_json);
     assert!(casm_class.is_ok());
 }

--- a/tests/integration/compile_raw.rs
+++ b/tests/integration/compile_raw.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 use test_case::test_case;
-use universal_sierra_compiler::commands;
+use universal_sierra_compiler::compile_raw;
 
 #[test]
 fn wrong_json() {
@@ -8,7 +8,7 @@ fn wrong_json() {
         "wrong": "data"
     });
 
-    let cairo_program = commands::compile_raw::compile(sierra_json);
+    let cairo_program = compile_raw(sierra_json);
     assert!(cairo_program.is_err());
 }
 
@@ -18,7 +18,7 @@ fn compile_raw_sierra(sierra_version: &str) {
     let file =
         File::open("tests/data/sierra_raw/sierra_".to_string() + sierra_version + ".json").unwrap();
     let artifact = serde_json::from_reader(file).unwrap();
-    let compiled = commands::compile_raw::compile(artifact);
+    let compiled = compile_raw(artifact);
 
     assert!(compiled.is_ok());
 }


### PR DESCRIPTION
Related to #35 

- changed visibility to only export compile functions
- added minor doc comments
- removed redundant `Cargo.toml` info
- updated `README.md`