### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Create GitHub release
         id: create-release
-        uses: taiki-e/create-gh-release-action@ceeaaf73c0f3f0cadd7bfd9b4d27de4076891fc2
+        uses: taiki-e/create-gh-release-action@b7abb0cf5e72cb5500307b577f9ca3fd4c5be9d2 # v1.8.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           changelog: CHANGELOG.md


### PR DESCRIPTION
In https://github.com/software-mansion/universal-sierra-compiler/pull/69 dependabot updated `taiki-e/create-gh-release-action` to a non-official release version `1.9.0`, which causes the release workflow to [fail](https://github.com/software-mansion/universal-sierra-compiler/actions/runs/13389710475/job/37397300619) due to incorrect flag usage in `gh release create` command.  This PR sets this action to the latest [1.8.4 version](https://github.com/taiki-e/create-gh-release-action/releases/tag/v1.8.4).