### PR TITLE
Optimize release builds for runtime performance 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1973,6 +1973,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2046,6 +2056,15 @@ checksum = "51d1790c73b93164ff65868f63164497cb32339458a9297e17e212d91df62258"
 dependencies = [
  "log",
  "sprs",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -3279,6 +3298,7 @@ dependencies = [
  "console",
  "fs_extra",
  "indoc 2.0.6",
+ "mimalloc",
  "num-bigint",
  "serde_core",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ version = "2.8.0-rc.0"
 edition = "2021"
 license = "MIT"
 
+[profile.release]
+codegen-units = 1
+lto = "thin"
 
 [dependencies]
 cairo-lang-starknet-sierra-0_1_0 = { package = "cairo-lang-starknet", git = "https://github.com/starkware-libs/cairo.git", tag = "v1.0.0-alpha.6", version = "1.0.0-alpha.6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tracing =  "0.1"
 chrono = { version = "0.4", optional = true }
 tracing-chrome = {version = "0.7", optional = true}
 tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter"] }
+mimalloc = "0.1"
 
 [dev-dependencies]
 snapbox = "0.6.21"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Error, Result};
 use cairo_lang_sierra::program::Program;
 use clap::{Parser, Subcommand};
 use console::style;
+use mimalloc::MiMalloc;
 use serde_json::{to_writer, Value};
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
@@ -11,6 +12,9 @@ mod commands;
 
 use commands::compile_contract::CompileContract;
 use commands::compile_raw::CompileRaw;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 #[derive(Parser)]
 #[command(version)]


### PR DESCRIPTION
Enable thin LTO
Set codegen-units to 1
Use mimalloc

On OZ openzeppelin_token_unittest.test.sierra.json & openzeppelin_governance_unittest.test.sierra.json

Before:
```
Benchmark 1: /Users/maciektr/Projects/universal-sierra-compiler/target/release/universal-sierra-compiler compile-raw --sierra-path openzeppelin_token_unittest.test.sierra.json > /dev/null && /Users/maciektr/Projects/universal-sierra-compiler/target/release/universal-sierra-compiler compile-raw --sierra-path openzeppelin_governance_unittest.test.sierra.json > /dev/null
  Time (mean ± σ):      3.242 s ±  0.034 s    [User: 2.975 s, System: 0.255 s]
  Range (min … max):    3.198 s …  3.302 s    10 runs
```

Thin LTO:
```
Benchmark 1: /Users/maciektr/Projects/universal-sierra-compiler/target/release/universal-sierra-compiler compile-raw --sierra-path openzeppelin_token_unittest.test.sierra.json > /dev/null && /Users/maciektr/Projects/universal-sierra-compiler/target/release/universal-sierra-compiler compile-raw --sierra-path openzeppelin_governance_unittest.test.sierra.json > /dev/null
  Time (mean ± σ):      3.063 s ±  0.042 s    [User: 2.792 s, System: 0.252 s]
  Range (min … max):    3.014 s …  3.145 s    10 runs
```

MiMalloc + ThinLTO:
```
Benchmark 1: /Users/maciektr/Projects/universal-sierra-compiler/target/release/universal-sierra-compiler compile-raw --sierra-path openzeppelin_token_unittest.test.sierra.json > /dev/null && /Users/maciektr/Projects/universal-sierra-compiler/target/release/universal-sierra-compiler compile-raw --sierra-path openzeppelin_governance_unittest.test.sierra.json > /dev/null
  Time (mean ± σ):      2.592 s ±  0.035 s    [User: 2.392 s, System: 0.182 s]
  Range (min … max):    2.552 s …  2.662 s    10 runs
```
