### PR TITLE
Export function gas costs in CASM artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,18 @@ $ universal-sierra-compiler \
     compile-raw \
       --sierra-path ./path/to/sierra.json
   
-{"assembled_cairo_program": ...}
+{
+  "assembled_cairo_program": ...,
+  "debug_info": ...,
+  "function_costs": {
+    "0": {"const": 10000, "pedersen": 1}
+  }
+}
 ```
+
+`function_costs` maps each raw Sierra function's entry-point statement index to its
+compiler-inferred cost-token counts. Consumers should price builtin tokens using the same
+builtin-cost table that is supplied to the compiled program at execution time.
 
 > 📝 **Note**
 >

--- a/src/commands/compile_raw.rs
+++ b/src/commands/compile_raw.rs
@@ -1,10 +1,11 @@
 use anyhow::{Context, Result};
 use cairo_lang_sierra::program::Program;
 use cairo_lang_sierra_to_casm::compiler::{CairoProgramDebugInfo, SierraToCasmConfig};
-use cairo_lang_sierra_to_casm::metadata::{calc_metadata, MetadataComputationConfig};
+use cairo_lang_sierra_to_casm::metadata::{calc_metadata, Metadata, MetadataComputationConfig};
 use cairo_lang_sierra_type_size::ProgramRegistryInfo;
 use clap::Args;
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use tracing::trace_span;
 
@@ -16,7 +17,7 @@ pub struct CompileRaw {
     pub sierra_path: PathBuf,
 
     /// Path to where compilation result json file will be saved.
-    /// It will consist of `assembled_cairo_program` and `debug_info` fields
+    /// It will consist of `assembled_cairo_program`, `debug_info` and `function_costs` fields
     #[arg(short, long)]
     pub output_path: Option<PathBuf>,
 }
@@ -60,9 +61,28 @@ pub fn compile(sierra_program: &Program) -> Result<Value> {
                 "bytecode": serde_json::to_value(assembled_cairo_program.bytecode)?,
                 "hints": serde_json::to_value(assembled_cairo_program.hints)?
             },
-            "debug_info": serde_json::to_value(serialize_cairo_program_debug_info(&cairo_program.debug_info))?
+            "debug_info": serde_json::to_value(serialize_cairo_program_debug_info(&cairo_program.debug_info))?,
+            "function_costs": serialize_function_costs(sierra_program, &metadata)
         })
     })
+}
+
+fn serialize_function_costs(
+    sierra_program: &Program,
+    metadata: &Metadata,
+) -> HashMap<usize, Map<String, Value>> {
+    sierra_program
+        .funcs
+        .iter()
+        .map(|function| {
+            let costs = metadata.gas_info.function_costs[&function.id]
+                .iter()
+                .map(|(token_type, value)| (token_type.name(), Value::from(*value)))
+                .collect();
+
+            (function.entry_point.0, costs)
+        })
+        .collect()
 }
 
 fn serialize_cairo_program_debug_info(debug_info: &CairoProgramDebugInfo) -> Vec<(usize, usize)> {

--- a/tests/e2e/compile_raw.rs
+++ b/tests/e2e/compile_raw.rs
@@ -19,10 +19,15 @@ fn verify_output_file(output_path: PathBuf) {
     );
     let debug_info =
         serde_json::from_value::<Vec<(usize, usize)>>(cairo_program_json["debug_info"].clone());
+    let function_costs = cairo_program_json["function_costs"].as_object().unwrap();
 
     assert!(bytecode.is_ok());
     assert!(hints.is_ok());
     assert!(debug_info.is_ok());
+    assert!(!function_costs.is_empty());
+    assert!(function_costs
+        .iter()
+        .all(|(entry_point, costs)| entry_point.parse::<usize>().is_ok() && costs.is_object()));
 }
 
 #[test]
@@ -59,6 +64,7 @@ fn write_to_stdout() {
     let output = String::from_utf8(snapbox.assert().success().get_output().stdout.clone()).unwrap();
     assert!(output.contains("assembled_cairo_program"));
     assert!(output.contains("debug_info"));
+    assert!(output.contains("function_costs"));
 }
 
 #[test]

--- a/tests/integration/compile_raw.rs
+++ b/tests/integration/compile_raw.rs
@@ -14,7 +14,16 @@ fn compile_raw_sierra(sierra_version: &str) {
     let file =
         File::open("tests/data/sierra_raw/sierra_".to_string() + sierra_version + ".json").unwrap();
     let artifact: Program = serde_json::from_reader(file).unwrap();
-    let compiled = compile_raw(&artifact);
+    let compiled = compile_raw(&artifact).unwrap();
+    let function_costs = compiled["function_costs"].as_object().unwrap();
 
-    assert!(compiled.is_ok());
+    assert_eq!(function_costs.len(), artifact.funcs.len());
+    assert!(function_costs
+        .values()
+        .any(|costs| !costs.as_object().unwrap().is_empty()));
+    assert!(artifact.funcs.iter().all(|function| {
+        function_costs
+            .get(&function.entry_point.0.to_string())
+            .is_some_and(serde_json::Value::is_object)
+    }));
 }


### PR DESCRIPTION
Part of https://github.com/foundry-rs/starknet-foundry/issues/4493

Forge treats raw Sierra functions as entrypoints by tricking the blockifier. To handle the entrypoint cost/gas refund, we need to know the gas cost of a function
